### PR TITLE
[Feat] Firebase 메시징 서비스 추가 및 푸시 알림 구현 (#20)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@
 .cxx
 local.properties
 /.idea/
+google-services.json

--- a/app/.gitignore
+++ b/app/.gitignore
@@ -1,1 +1,2 @@
 /build
+google-services.json

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.ksp)
-//    alias(libs.plugins.google.services)
+    alias(libs.plugins.google.services)
 }
 
 android {
@@ -30,7 +30,7 @@ android {
             isMinifyEnabled = true
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
-                "proguard-rules.pro"
+                "proguard-rules.pro",
             )
         }
     }
@@ -93,6 +93,7 @@ dependencies {
     // Firebase
     implementation(platform(libs.firebase.bom))
     implementation(libs.firebase.firestore)
+    implementation(libs.firebase.messaging)
 
     // Coil (Image Loading)
     implementation(libs.coil.compose)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -23,6 +23,22 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <service
+            android:name=".data.service.MyFirebaseMessagingService"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="com.google.firebase.MESSAGING_EVENT" />
+            </intent-filter>
+        </service>
+
+        <meta-data
+            android:name="com.google.firebase.messaging.default_notification_icon"
+            android:resource="@drawable/ic_notification_filled" />
+        <meta-data
+            android:name="com.google.firebase.messaging.default_notification_channel_id"
+            android:value="default_channel_id" />
     </application>
+
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
 </manifest>

--- a/app/src/main/java/com/devhjs/ttackjigeum_android/MainActivity.kt
+++ b/app/src/main/java/com/devhjs/ttackjigeum_android/MainActivity.kt
@@ -1,14 +1,30 @@
 package com.devhjs.ttackjigeum_android
 
 import android.os.Bundle
+import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import com.devhjs.ttackjigeum_android.presentation.MyApp
+import com.google.firebase.messaging.FirebaseMessaging
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        
+        FirebaseMessaging.getInstance().token.addOnCompleteListener { task ->
+            if (!task.isSuccessful) {
+                Log.w("FCM_TEST", "토큰 가져오기 실패", task.exception)
+                return@addOnCompleteListener
+            }
+            val token = task.result
+            Log.d("FCM_TEST", "내 기기 토큰: $token")
+        }
+
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.TIRAMISU) {
+            requestPermissions(arrayOf(android.Manifest.permission.POST_NOTIFICATIONS), 99)
+        }
+
         enableEdgeToEdge()
         setContent {
             MyApp()

--- a/app/src/main/java/com/devhjs/ttackjigeum_android/data/service/MyFirebaseMessagingService.kt
+++ b/app/src/main/java/com/devhjs/ttackjigeum_android/data/service/MyFirebaseMessagingService.kt
@@ -1,0 +1,91 @@
+package com.devhjs.ttackjigeum_android.data.service
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.media.RingtoneManager
+import android.os.Build
+import android.util.Log
+import androidx.core.app.NotificationCompat
+import com.devhjs.ttackjigeum_android.MainActivity
+import com.devhjs.ttackjigeum_android.R
+import com.google.firebase.messaging.FirebaseMessagingService
+import com.google.firebase.messaging.RemoteMessage
+
+class MyFirebaseMessagingService : FirebaseMessagingService() {
+
+    override fun onMessageReceived(remoteMessage: RemoteMessage) {
+        // TODO(developer): Handle FCM messages here.
+        // Not getting messages here? See why this may be: https://goo.gl/39bRNJ
+        Log.d(TAG, "From: ${remoteMessage.from}")
+
+        // Check if message contains a data payload.
+        if (remoteMessage.data.isNotEmpty()) {
+            Log.d(TAG, "Message data payload: ${remoteMessage.data}")
+            handleNow()
+        }
+
+        // Check if message contains a notification payload.
+        remoteMessage.notification?.let {
+            Log.d(TAG, "Message Notification Body: ${it.body}")
+            sendNotification(it.title ?: "알림", it.body ?: "")
+        } ?: run {
+            // Handle data payload as notification if no notification payload
+            val title = remoteMessage.data["title"]
+            val body = remoteMessage.data["body"]
+            if (!title.isNullOrEmpty() && !body.isNullOrEmpty()) {
+                sendNotification(title, body)
+            }
+        }
+    }
+
+    override fun onNewToken(token: String) {
+        Log.d(TAG, "Refreshed token: $token")
+        sendRegistrationToServer(token)
+    }
+
+    private fun handleNow() {
+        Log.d(TAG, "Short lived task is done.")
+    }
+
+    private fun sendRegistrationToServer(token: String?) {
+        // TODO: Implement this method to send token to your app server.
+        Log.d(TAG, "sendRegistrationTokenToServer($token)")
+    }
+
+    private fun sendNotification(title: String, messageBody: String) {
+        val intent = Intent(this, MainActivity::class.java)
+        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
+        val pendingIntent = PendingIntent.getActivity(this, 0 /* Request code */, intent,
+            PendingIntent.FLAG_IMMUTABLE)
+
+        val channelId = "default_channel_id"
+        val defaultSoundUri = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION)
+        val notificationBuilder = NotificationCompat.Builder(this, channelId)
+            .setSmallIcon(R.drawable.ic_notification_filled) // Using launcher foreground as fallback/standard if ic_notification_filled is not preferred or to ensure visibility
+            .setContentTitle(title)
+            .setContentText(messageBody)
+            .setAutoCancel(true)
+            .setSound(defaultSoundUri)
+            .setPriority(NotificationCompat.PRIORITY_HIGH)
+            .setContentIntent(pendingIntent)
+
+        val notificationManager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+
+        // Since android Oreo notification channel is needed.
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val channel = NotificationChannel(channelId,
+                "Default Channel",
+                NotificationManager.IMPORTANCE_HIGH)
+            notificationManager.createNotificationChannel(channel)
+        }
+
+        notificationManager.notify(0 /* ID of notification */, notificationBuilder.build())
+    }
+
+    companion object {
+        private const val TAG = "MyFirebaseMsgService"
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,5 +5,5 @@ plugins {
     alias(libs.plugins.kotlin.compose) apply false
     alias(libs.plugins.kotlin.serialization) apply false
     alias(libs.plugins.ksp) apply false
-//    alias(libs.plugins.google.services) apply false
+    alias(libs.plugins.google.services) apply false
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -40,6 +40,7 @@ turbine = "1.2.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
+firebase-messaging = { module = "com.google.firebase:firebase-messaging" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }


### PR DESCRIPTION
<!--
PR 제목 규칙 반드시 지켜주세요
[Feat] 기능 요약 (#이슈번호)
[Fix] 버그 요약 (#이슈번호)
[Refacotr] 리팩토링 요약 (#이슈번호)
등등
-->

## 🧪 Topic

<!-- 해당하는 작업 주제를 선택해주세요 -->

- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

## 📌 Summary

- MyFirebaseMessagingService 클래스 작성 및 메시지 이벤트 처리 구현
- Firebase Cloud Messaging 의존성 및 관련 gradle 설정 추가
- AndroidManifest에 서비스 등록 및 알림 채널/권한 설정 추가
- MainActivity에서 기기 FCM 토큰 요청 및 권한 요청 처리
- google-services.json 관련 gitignore 항목 업데이트

## 🔍 Related Issue

<!-- Issue Close 를 하고 싶지 않다면 Closes 를 지워주세요 -->

- #20 

## 📸 Screen Shot (Optional)

<!-- UI 변경 사항이 있다면 스크린샷이나 GIF로 첨부해주세요. -->

## 비고 / 참고 사항

<!-- 리뷰어 참고사항이 있다면 작성해주세요. -->