### PR TITLE
[Refactor] 목표가 변경 슬라이더 단위 조정 및 키보드 입력 추가, 가격 상승 뱃지 추가(#94)

### DIFF
--- a/app/src/main/java/com/devhjs/ttackjigeum_android/core/util/KeyboardUtils.kt
+++ b/app/src/main/java/com/devhjs/ttackjigeum_android/core/util/KeyboardUtils.kt
@@ -1,0 +1,72 @@
+package com.devhjs.ttackjigeum_android.core.util
+
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusManager
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.foundation.text.KeyboardActions
+
+/**
+ * 키보드 및 포커스 관련 유틸리티 확장 함수들
+ */
+
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.input.OffsetMapping
+import androidx.compose.ui.text.input.TransformedText
+import androidx.compose.ui.text.input.VisualTransformation
+import java.text.DecimalFormat
+
+/**
+ * 숫자를 3자리마다 콤마가 찍힌 금액 형식으로 변환해주는 VisualTransformation입니다.
+ */
+class PriceVisualTransformation : VisualTransformation {
+    override fun filter(text: AnnotatedString): TransformedText {
+        val originalText = text.text
+        if (originalText.isEmpty()) return TransformedText(text, OffsetMapping.Identity)
+
+        val formatter = DecimalFormat("#,###")
+        val formattedText = formatter.format(originalText.toLong())
+
+        val offsetMapping = object : OffsetMapping {
+            override fun originalToTransformed(offset: Int): Int {
+                if (offset <= 0) return 0
+                val subString = originalText.substring(0, offset)
+                return formatter.format(subString.toLong()).length
+            }
+
+            override fun transformedToOriginal(offset: Int): Int {
+                val commasBefore = formattedText.substring(0, offset).count { it == ',' }
+                return (offset - commasBefore).coerceIn(0, originalText.length)
+            }
+        }
+
+        return TransformedText(AnnotatedString(formattedText), offsetMapping)
+    }
+}
+
+/**
+ * '완료(Done)' 액션 시 포커스를 해제하는 KeyboardActions를 반환합니다.
+ */
+fun clearFocusOnDone(focusManager: FocusManager): KeyboardActions {
+    return KeyboardActions(onDone = { focusManager.clearFocus() })
+}
+
+/**
+ * 화면의 빈 공간을 터치했을 때 포커스를 해제하고 키보드를 내리는 Modifier입니다.
+ *
+ * 사용법:
+ * val focusManager = LocalFocusManager.current
+ * Column(
+ *     modifier = Modifier
+ *         .fillMaxSize()
+ *         .addFocusCleaner(focusManager)
+ * ) { ... }
+ */
+fun Modifier.addFocusCleaner(focusManager: FocusManager, doOnClear: () -> Unit = {}): Modifier {
+    return this.pointerInput(Unit) {
+        detectTapGestures(onTap = {
+            doOnClear()
+            focusManager.clearFocus()
+        })
+    }
+}

--- a/app/src/main/java/com/devhjs/ttackjigeum_android/presentation/component/ProductBadge.kt
+++ b/app/src/main/java/com/devhjs/ttackjigeum_android/presentation/component/ProductBadge.kt
@@ -42,6 +42,13 @@ enum class BadgeType(
         iconResId = R.drawable.ic_trending_down,
         iconTint = AppColors.Primary
     ),
+    PRICE_RISE(
+        text = "가격 상승",
+        textColor = AppColors.Warning1,
+        backgroundColor = AppColors.Warning2,
+        iconResId = R.drawable.ic_trending_up,
+        iconTint = AppColors.Warning1
+    ),
     NO_CHANGE(
         text = "변동 없음",
         textColor = AppColors.TextGray1,
@@ -94,6 +101,12 @@ fun PreviewLowestPriceBadge() {
 @Composable
 fun PreviewPriceDropBadge() {
     ProductBadge(type = BadgeType.PRICE_DROP)
+}
+
+@Preview(showBackground = true, name = "Price Rise")
+@Composable
+fun PreviewPriceRiseBadge() {
+    ProductBadge(type = BadgeType.PRICE_RISE)
 }
 
 @Preview(showBackground = true, name = "No Change")

--- a/app/src/main/java/com/devhjs/ttackjigeum_android/presentation/component/ProductCardItem.kt
+++ b/app/src/main/java/com/devhjs/ttackjigeum_android/presentation/component/ProductCardItem.kt
@@ -54,6 +54,7 @@ fun ProductCardItem(
     val badgeType = when {
         product.currentPrice <= product.lowestPrice -> BadgeType.LOWEST_PRICE
         product.currentPrice < product.originalPrice -> BadgeType.PRICE_DROP
+        product.currentPrice > product.originalPrice -> BadgeType.PRICE_RISE
         else -> BadgeType.NO_CHANGE
     }
 
@@ -196,6 +197,24 @@ fun PreviewProductCardItem() {
         name = "소니 WH-1000XM5 무선 노이즈 캔셀링 헤드폰",
         originalPrice = 350000,
         currentPrice = 298000,
+        targetPrice = 320000,
+        lowestPrice = 290000,
+        averagePrice = 330000,
+        isFavorite = false,
+        url = "",
+        imageUrl = "",
+    )
+    ProductCardItem(product = mockProduct)
+}
+
+@Preview(showBackground = true)
+@Composable
+fun PreviewProductCardItemRise() {
+    val mockProduct = Product(
+        id = 2L,
+        name = "가격 상승 예시 상품",
+        originalPrice = 300000,
+        currentPrice = 350000,
         targetPrice = 320000,
         lowestPrice = 290000,
         averagePrice = 330000,

--- a/app/src/main/java/com/devhjs/ttackjigeum_android/presentation/component/TargetPriceSlider.kt
+++ b/app/src/main/java/com/devhjs/ttackjigeum_android/presentation/component/TargetPriceSlider.kt
@@ -4,14 +4,18 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -27,10 +31,17 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.devhjs.ttackjigeum_android.ui.theme.AppTextStyles
 import com.devhjs.ttackjigeum_android.ui.theme.AppColors
+import com.devhjs.ttackjigeum_android.core.util.clearFocusOnDone
+import com.devhjs.ttackjigeum_android.core.util.PriceVisualTransformation
+import kotlin.math.round
 
 @Composable
 fun TargetPriceSlider(
@@ -39,14 +50,11 @@ fun TargetPriceSlider(
     currentPrice: Int,
     onTargetPriceChange: (Int) -> Unit
 ) {
-    // Determine min/max range based on prices
-    // Example logic: Min = 0, Max = Current Price * 1.5 (or similar)
-    // For now, let's keep hardcoded range logic or passed params.
-    // User asked to modify data.
-    // Let's assume range is dynamic.
-    val minPrice = (currentPrice * 0.5).toInt() // Example: 50% of current
-    val maxPrice = (currentPrice * 1.2).toInt() // Example: 120% of current
+    val minPrice = remember(currentPrice) { (currentPrice * 0.5).toInt() }
+    val maxPrice = remember(currentPrice) { (currentPrice * 1.5).toInt() }
+    
     var sliderValue by remember(targetPrice) { mutableFloatStateOf(targetPrice.toFloat()) }
+    val focusManager = LocalFocusManager.current
 
     Card(
         modifier = modifier
@@ -77,31 +85,30 @@ fun TargetPriceSlider(
                     )
                 }
                 
-                Card(
-                    shape = RoundedCornerShape(8.dp),
-                    colors = CardDefaults.cardColors(containerColor = AppColors.IconGray2),
-                    modifier = Modifier.padding(start = 8.dp)
-                ) {
-                    Text(
-                        text = "₩${String.format("%,d", sliderValue.toInt())}",
-                        style = AppTextStyles.mediumTextBold,
-                        modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp)
-                    )
-                }
+                PriceInputBox(
+                    value = sliderValue.toInt(),
+                    onValueChange = { 
+                        sliderValue = it.toFloat()
+                        onTargetPriceChange(it)
+                    },
+                    focusManager = focusManager
+                )
             }
 
             Spacer(modifier = Modifier.height(24.dp))
 
             @OptIn(ExperimentalMaterial3Api::class)
             Slider(
-                value = sliderValue,
-                onValueChange = { sliderValue = it },
+                value = sliderValue.coerceIn(minPrice.toFloat(), maxPrice.toFloat()),
+                onValueChange = {
+                    val step = 100f
+                    sliderValue = round(it / step) * step
+                },
                 onValueChangeFinished = {
                     onTargetPriceChange(sliderValue.toInt())
                 },
                 valueRange = minPrice.toFloat()..maxPrice.toFloat(),
                 thumb = {
-                    // Custom Thumb
                     Box(
                         modifier = Modifier
                             .size(32.dp)
@@ -112,7 +119,6 @@ fun TargetPriceSlider(
                     )
                 },
                 track = { sliderState ->
-                    // Custom Track
                     SliderDefaults.Track(
                         sliderState = sliderState,
                         modifier = Modifier.height(10.dp),
@@ -132,17 +138,54 @@ fun TargetPriceSlider(
             ) {
                 Text(
                     text = "₩${String.format("%,d", minPrice)}",
-                    style = AppTextStyles.smallerTextBold.copy(
-                        color = AppColors.TextGray2
-                    )
+                    style = AppTextStyles.smallerTextBold.copy(color = AppColors.TextGray2)
                 )
                 Text(
                     text = "₩${String.format("%,d", maxPrice)}",
-                    style = AppTextStyles.smallerTextBold.copy(
-                        color = AppColors.TextGray2
-                    )
+                    style = AppTextStyles.smallerTextBold.copy(color = AppColors.TextGray2)
                 )
             }
+        }
+    }
+}
+
+@Composable
+private fun PriceInputBox(
+    value: Int,
+    onValueChange: (Int) -> Unit,
+    focusManager: androidx.compose.ui.focus.FocusManager
+) {
+    Card(
+        shape = RoundedCornerShape(8.dp),
+        colors = CardDefaults.cardColors(containerColor = AppColors.IconGray2),
+        modifier = Modifier.padding(start = 8.dp)
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = "₩",
+                style = AppTextStyles.mediumTextBold
+            )
+            BasicTextField(
+                value = if (value == 0) "" else value.toString(),
+                onValueChange = { newValue ->
+                    val filtered = newValue.filter { it.isDigit() }
+                    val price = if (filtered.isEmpty()) 0 else filtered.toLong().coerceAtMost(Int.MAX_VALUE.toLong()).toInt()
+                    onValueChange(price)
+                },
+                textStyle = AppTextStyles.mediumTextBold,
+                keyboardOptions = KeyboardOptions(
+                    keyboardType = KeyboardType.Number,
+                    imeAction = ImeAction.Done
+                ),
+                keyboardActions = clearFocusOnDone(focusManager),
+                singleLine = true,
+                cursorBrush = SolidColor(AppColors.Primary),
+                visualTransformation = PriceVisualTransformation(),
+                modifier = Modifier.width(IntrinsicSize.Min)
+            )
         }
     }
 }


### PR DESCRIPTION
<!--
PR 제목 규칙 반드시 지켜주세요
[Feat] 기능 요약 (#이슈번호)
[Fix] 버그 요약 (#이슈번호)
[Refacotr] 리팩토링 요약 (#이슈번호)
등등
-->

## 🧪 Topic

<!-- 해당하는 작업 주제를 선택해주세요 -->

- [ ] 기능 추가
- [ ] 리뷰 반영
- [X] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

## 📌 Summary

- TargetPriceSlider에 텍스트 입력을 위한 PriceInputBox 추가
- Slider 조작 시 100단위로 값이 조정되도록 스텝 로직 적용
- 금액 표시 및 입력을 위한 PriceVisualTransformation 유틸리티 구현
- 키보드 완료 액션 시 포커스 해제 및 키보드 숨김 처리 추가
- 현재 가격 대비 슬라이더의 최소/최대 가동 범위 조정 및 최적화
- BadgeType에 PRICE_RISE 타입을 추가하여 가격 상승 상태 정의
- ProductCardItem에 현재가가 원래 가격보다 높을 경우 상승 배지 노출 로직 구현
- ProductBadge 및 ProductCardItem에 가격 상승 상태 프리뷰 추가
- 상승 상태에 맞는 경고 색상 및 아이콘 리소스 적용

## 🔍 Related Issue

<!-- Issue Close 를 하고 싶지 않다면 Closes 를 지워주세요 -->

- #94 

## 📸 Screen Shot (Optional)

<!-- UI 변경 사항이 있다면 스크린샷이나 GIF로 첨부해주세요. -->
<img height="300" alt="image" src="https://github.com/user-attachments/assets/a3eda790-e638-4585-9ccf-af611d51c32e" />
<img  height="300" alt="image" src="https://github.com/user-attachments/assets/d0d701a6-3206-44b7-b465-2572de4a02a2" />
<img width="504" height="214" alt="image" src="https://github.com/user-attachments/assets/b606aee6-0038-4d44-a98d-ea2a22231fe5" />



## 비고 / 참고 사항

<!-- 리뷰어 참고사항이 있다면 작성해주세요. -->