### PR TITLE
[Refactor] Firestore 쿼리 효율화 및 데이터 정렬 로직 개선(#97)

### DIFF
--- a/app/src/main/java/com/devhjs/ttackjigeum_android/data/local/dao/UserConfigDao.kt
+++ b/app/src/main/java/com/devhjs/ttackjigeum_android/data/local/dao/UserConfigDao.kt
@@ -15,10 +15,10 @@ interface UserConfigDao {
     @Query("SELECT * FROM user_configs WHERE product_id = :productId")
     suspend fun findById(productId: Long): UserConfigEntity?
 
-    @Query("SELECT * FROM user_configs ORDER BY product_id ASC")
+    @Query("SELECT * FROM user_configs ORDER BY product_id DESC")
     suspend fun getAll(): List<UserConfigEntity>
 
-    @Query("SELECT * FROM user_configs ORDER BY product_id ASC")
+    @Query("SELECT * FROM user_configs ORDER BY product_id DESC")
     fun getAllFlow(): Flow<List<UserConfigEntity>>
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)

--- a/app/src/main/java/com/devhjs/ttackjigeum_android/data/repository/FirestoreProductRepositoryImpl.kt
+++ b/app/src/main/java/com/devhjs/ttackjigeum_android/data/repository/FirestoreProductRepositoryImpl.kt
@@ -6,6 +6,8 @@ import com.devhjs.ttackjigeum_android.data.mapper.toDto
 import com.devhjs.ttackjigeum_android.domain.model.Product
 import com.devhjs.ttackjigeum_android.domain.repository.ProductRepository
 import com.google.firebase.firestore.FirebaseFirestore
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.tasks.await
 
 class FirestoreProductRepositoryImpl(
@@ -45,24 +47,27 @@ class FirestoreProductRepositoryImpl(
         }
     }
 
-    override suspend fun getProductByIds(ids: List<Long>): List<Product> {
-        if (ids.isEmpty()) return emptyList()
-        return try {
-            // Firestore의 'in' 쿼리는 일반적으로 최대 10개의 값을 지원하지만, 여기서는 간단하게 whereIn을 시도합니다.
-            // 리스트가 큰 경우 여러 쿼리가 필요할 수 있습니다. 현재는 작은 리스트라고 가정합니다.
-            val snapshot = firestore.collection(collectionRegex)
-                .whereIn("id", ids)
-                .get()
-                .await()
+    override suspend fun getProductByIds(ids: List<Long>): List<Product> =
+        kotlinx.coroutines.coroutineScope {
+            if (ids.isEmpty()) return@coroutineScope emptyList()
+            return@coroutineScope try {
+                ids.chunked(10).map { chunk ->
+                    async {
+                        val snapshot = firestore.collection(collectionRegex)
+                            .whereIn("id", chunk)
+                            .get()
+                            .await()
 
-            snapshot.documents.mapNotNull { document ->
-                document.toObject(ProductDto::class.java)?.toDomain()
+                        snapshot.documents.mapNotNull { document ->
+                            document.toObject(ProductDto::class.java)?.toDomain()
+                        }
+                    }
+                }.awaitAll().flatten()
+            } catch (e: Exception) {
+                e.printStackTrace()
+                emptyList()
             }
-        } catch (e: Exception) {
-            e.printStackTrace()
-            emptyList()
         }
-    }
 
     override suspend fun addProduct(product: Product) {
         try {

--- a/app/src/main/java/com/devhjs/ttackjigeum_android/data/repository/FirestoreUserConfigRepositoryImpl.kt
+++ b/app/src/main/java/com/devhjs/ttackjigeum_android/data/repository/FirestoreUserConfigRepositoryImpl.kt
@@ -5,6 +5,7 @@ import com.devhjs.ttackjigeum_android.data.dto.UserConfigDto
 import com.devhjs.ttackjigeum_android.domain.model.UserConfig
 import com.devhjs.ttackjigeum_android.domain.repository.UserConfigRepository
 import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.Query
 import com.google.firebase.firestore.SetOptions
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
@@ -39,9 +40,13 @@ class FirestoreUserConfigRepositoryImpl(
         }
     }
 
+
     override suspend fun getAllUserConfigs(): List<UserConfig> {
         return try {
-            val snapshot = getUserCollection().get().await()
+            val snapshot = getUserCollection()
+                .orderBy("productId", Query.Direction.DESCENDING)
+                .get()
+                .await()
             snapshot.documents.mapNotNull { doc ->
                 val dto = doc.toObject(UserConfigDto::class.java)
                 dto?.let {
@@ -59,26 +64,28 @@ class FirestoreUserConfigRepositoryImpl(
     }
 
     override fun getAllUserConfigsFlow(): Flow<List<UserConfig>> = callbackFlow {
-        val listener = getUserCollection().addSnapshotListener { snapshot, error ->
-            if (error != null) {
-                close(error)
-                return@addSnapshotListener
-            }
-
-            if (snapshot != null) {
-                val configs = snapshot.documents.mapNotNull { doc ->
-                    val dto = doc.toObject(UserConfigDto::class.java)
-                    dto?.let {
-                        UserConfig(
-                            productId = it.productId ?: doc.id.toLongOrNull() ?: 0L,
-                            targetPrice = it.targetPrice ?: 0,
-                            notificationEnabled = it.notificationEnabled ?: false
-                        )
-                    }
+        val listener = getUserCollection()
+            .orderBy("productId", Query.Direction.DESCENDING)
+            .addSnapshotListener { snapshot, error ->
+                if (error != null) {
+                    close(error)
+                    return@addSnapshotListener
                 }
-                trySend(configs)
+
+                if (snapshot != null) {
+                    val configs = snapshot.documents.mapNotNull { doc ->
+                        val dto = doc.toObject(UserConfigDto::class.java)
+                        dto?.let {
+                            UserConfig(
+                                productId = it.productId ?: doc.id.toLongOrNull() ?: 0L,
+                                targetPrice = it.targetPrice ?: 0,
+                                notificationEnabled = it.notificationEnabled ?: false
+                            )
+                        }
+                    }
+                    trySend(configs)
+                }
             }
-        }
         awaitClose { listener.remove() }
     }
 

--- a/app/src/main/java/com/devhjs/ttackjigeum_android/domain/usecase/GetProductsUseCase.kt
+++ b/app/src/main/java/com/devhjs/ttackjigeum_android/domain/usecase/GetProductsUseCase.kt
@@ -20,14 +20,11 @@ class GetProductsUseCase(
             try {
                 val productIds = userConfigs.map { it.productId }
                 val products = productRepository.getProductByIds(productIds)
+                val productMap = products.associateBy { it.id }
 
-                val updatedProducts = products.map { product ->
-                    val config = userConfigs.find { it.productId == product.id }
-                    if (config != null) {
-                        product.copy(targetPrice = config.targetPrice)
-                    } else {
-                        product
-                    }
+                val updatedProducts = userConfigs.mapNotNull { config ->
+                    val product = productMap[config.productId]
+                    product?.copy(targetPrice = config.targetPrice)
                 }
 
                 Result.Success(updatedProducts)


### PR DESCRIPTION
<!--
PR 제목 규칙 반드시 지켜주세요
[Feat] 기능 요약 (#이슈번호)
[Fix] 버그 요약 (#이슈번호)
[Refacotr] 리팩토링 요약 (#이슈번호)
등등
-->

## 🧪 Topic

<!-- 해당하는 작업 주제를 선택해주세요 -->

- [ ] 기능 추가
- [ ] 리뷰 반영
- [X] 리팩토링
- [X] 버그 수정
- [ ] 컨벤션 수정

## 📌 Summary

- Firestore의 `whereIn` 쿼리 10개 제한 문제를 `chunked` 및 `async`를 활용한 병렬 처리로 해결
- Firestore 및 Local DB의 `UserConfig` 조회 시 `productId` 기준 내림차순 정렬 추가
- `GetProductsUseCase`에서 리스트 순회 로직을 `Map` 기반의 `mapNotNull` 구조로 변경하여 성능 최적화
- `coroutineScope`를 적용하여 `getProductByIds`의 비동기 작업 안정성 확보

## 🔍 Related Issue

<!-- Issue Close 를 하고 싶지 않다면 Closes 를 지워주세요 -->

- #97 

## 📸 Screen Shot (Optional)

<!-- UI 변경 사항이 있다면 스크린샷이나 GIF로 첨부해주세요. -->

## 비고 / 참고 사항

<!-- 리뷰어 참고사항이 있다면 작성해주세요. -->