### PR TITLE
[Fix] 상품 검색 UseCase 구조 개선 및 키보드 포커스 제어 최적화 (#107)

### DIFF
--- a/app/src/main/java/com/devhjs/ttackjigeum_android/core/di/UseCaseModule.kt
+++ b/app/src/main/java/com/devhjs/ttackjigeum_android/core/di/UseCaseModule.kt
@@ -15,7 +15,7 @@ val useCaseModule = module {
     single { GetProductUseCase(get(), get()) }
     single { GetProductsUseCase(get(), get(), get()) }
     single { GetPriceHistoryUseCase(get()) }
-    single { SearchProductsUseCase(get()) }
+    single { SearchProductsUseCase() }
     single { GetUserConfigUseCase(get()) }
     single { ToggleProductNotificationUseCase(get()) }
     single { AddProductUseCase(get(), get(), get()) }

--- a/app/src/main/java/com/devhjs/ttackjigeum_android/core/di/ViewModelModule.kt
+++ b/app/src/main/java/com/devhjs/ttackjigeum_android/core/di/ViewModelModule.kt
@@ -8,6 +8,6 @@ import org.koin.dsl.module
 
 
 val viewModelModule = module {
-    viewModel { ListViewModel(get(), get(), get(), get()) }
-    viewModel { (route: Long) -> DetailViewModel(route, get(), get(),get(),get(), get()) }
+    viewModel { ListViewModel(get(), get(), get(), get(), get()) }
+    viewModel { (route: Long) -> DetailViewModel(route, get(), get(), get(), get(), get()) }
 }

--- a/app/src/main/java/com/devhjs/ttackjigeum_android/core/util/KeyboardUtils.kt
+++ b/app/src/main/java/com/devhjs/ttackjigeum_android/core/util/KeyboardUtils.kt
@@ -1,20 +1,28 @@
 package com.devhjs.ttackjigeum_android.core.util
 
 import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.ime
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusManager
 import androidx.compose.ui.input.pointer.pointerInput
-import androidx.compose.foundation.text.KeyboardActions
-
-/**
- * 키보드 및 포커스 관련 유틸리티 확장 함수들
- */
-
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.input.OffsetMapping
 import androidx.compose.ui.text.input.TransformedText
 import androidx.compose.ui.text.input.VisualTransformation
 import java.text.DecimalFormat
+
+/**
+ * 키보드 및 포커스 관련 유틸리티 확장 함수들
+ */
+
 
 /**
  * 숫자를 3자리마다 콤마가 찍힌 금액 형식으로 변환해주는 VisualTransformation입니다.
@@ -51,6 +59,7 @@ fun clearFocusOnDone(focusManager: FocusManager): KeyboardActions {
     return KeyboardActions(onDone = { focusManager.clearFocus() })
 }
 
+
 /**
  * 화면의 빈 공간을 터치했을 때 포커스를 해제하고 키보드를 내리는 Modifier입니다.
  *
@@ -68,5 +77,26 @@ fun Modifier.addFocusCleaner(focusManager: FocusManager, doOnClear: () -> Unit =
             doOnClear()
             focusManager.clearFocus()
         })
+    }
+}
+
+/**
+ * 키보드가 닫힐 때(시스템 백 버튼 등) 자동으로 포커스를 해제하는 Effect입니다.
+ *
+ * @param isFocused 현재 컴포넌트(TextField 등)가 포커스 상태인지 여부
+ * @param focusManager 포커스를 제어할 FocusManager (기본값: LocalFocusManager.current)
+ */
+@Composable
+fun ClearFocusOnKeyboardDismissEffect(
+    isFocused: Boolean,
+    focusManager: FocusManager = LocalFocusManager.current
+) {
+    val isImeVisible = WindowInsets.ime.getBottom(LocalDensity.current) > 0
+    val currentIsFocused by rememberUpdatedState(isFocused)
+
+    LaunchedEffect(isImeVisible) {
+        if (!isImeVisible && currentIsFocused) {
+            focusManager.clearFocus()
+        }
     }
 }

--- a/app/src/main/java/com/devhjs/ttackjigeum_android/domain/usecase/SearchProductsUseCase.kt
+++ b/app/src/main/java/com/devhjs/ttackjigeum_android/domain/usecase/SearchProductsUseCase.kt
@@ -1,32 +1,14 @@
 package com.devhjs.ttackjigeum_android.domain.usecase
 
-import com.devhjs.ttackjigeum_android.core.util.DataError
-import com.devhjs.ttackjigeum_android.core.util.Result
 import com.devhjs.ttackjigeum_android.domain.model.Product
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.map
 
-class SearchProductsUseCase(
-    private val getProductsUseCase: GetProductsUseCase
-) {
-    operator fun invoke(query: String): Flow<Result<List<Product>, DataError>> {
-        return getProductsUseCase().map { result ->
-            when (result) {
-                is Result.Success -> {
-                    if (query.isBlank()) {
-                        Result.Success(result.data)
-                    } else {
-                        val filtered = result.data.filter {
-                            it.name.contains(query, ignoreCase = true)
-                        }
-                        Result.Success(filtered)
-                    }
-                }
-
-                is Result.Error -> {
-                    result
-                }
-            }
+class SearchProductsUseCase {
+    operator fun invoke(products: List<Product>, query: String): List<Product> {
+        if (query.isBlank()) {
+            return products
+        }
+        return products.filter {
+            it.name.contains(query, ignoreCase = true)
         }
     }
 }

--- a/app/src/main/java/com/devhjs/ttackjigeum_android/presentation/component/SearchBar.kt
+++ b/app/src/main/java/com/devhjs/ttackjigeum_android/presentation/component/SearchBar.kt
@@ -12,6 +12,8 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -23,21 +25,28 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.devhjs.ttackjigeum_android.R
+import com.devhjs.ttackjigeum_android.core.util.ClearFocusOnKeyboardDismissEffect
 import com.devhjs.ttackjigeum_android.ui.theme.AppColors
 
 @Composable
 fun SearchBar(
     modifier: Modifier = Modifier,
     value: String,
-    onValueChange: (String) -> Unit= {},
+    onValueChange: (String) -> Unit = {},
 ) {
     var isFocused by remember { mutableStateOf(false) }
+    val focusManager = LocalFocusManager.current
+
+    // 키보드 가시성 감지 및 포커스 해제
+    ClearFocusOnKeyboardDismissEffect(isFocused = isFocused)
 
     Row(
         modifier = modifier
@@ -85,6 +94,12 @@ fun SearchBar(
                     fontSize = 16.sp,
                     color = Color.Black,
                 ),
+                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
+                keyboardActions = KeyboardActions(
+                    onSearch = {
+                        focusManager.clearFocus()
+                    }
+                )
             )
         }
     }

--- a/app/src/main/java/com/devhjs/ttackjigeum_android/presentation/component/TargetPriceSlider.kt
+++ b/app/src/main/java/com/devhjs/ttackjigeum_android/presentation/component/TargetPriceSlider.kt
@@ -28,6 +28,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -41,6 +42,7 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.devhjs.ttackjigeum_android.core.util.ClearFocusOnKeyboardDismissEffect
 import com.devhjs.ttackjigeum_android.core.util.PriceVisualTransformation
 import com.devhjs.ttackjigeum_android.ui.theme.AppColors
 import com.devhjs.ttackjigeum_android.ui.theme.AppTextStyles
@@ -163,6 +165,10 @@ private fun PriceInputBox(
     focusManager: androidx.compose.ui.focus.FocusManager
 ) {
     val context = LocalContext.current
+    var isFocused by remember { mutableStateOf(false) }
+    
+    // 키보드가 내려가면 포커스 해제
+    ClearFocusOnKeyboardDismissEffect(isFocused = isFocused)
 
     Card(
         shape = RoundedCornerShape(8.dp),
@@ -203,6 +209,7 @@ private fun PriceInputBox(
                 modifier = Modifier
                     .width(IntrinsicSize.Min)
                     .onFocusChanged { focusState ->
+                        isFocused = focusState.isFocused
                         if (!focusState.isFocused) {
                             validateAndCorrectPrice(
                                 context,

--- a/app/src/main/java/com/devhjs/ttackjigeum_android/presentation/list/ListScreen.kt
+++ b/app/src/main/java/com/devhjs/ttackjigeum_android/presentation/list/ListScreen.kt
@@ -27,6 +27,8 @@ import com.devhjs.ttackjigeum_android.presentation.component.ProductCardItem
 import com.devhjs.ttackjigeum_android.presentation.component.SearchBar
 import com.devhjs.ttackjigeum_android.ui.theme.AppColors
 import com.devhjs.ttackjigeum_android.ui.theme.AppTextStyles
+import androidx.compose.ui.platform.LocalFocusManager
+import com.devhjs.ttackjigeum_android.core.util.addFocusCleaner
 
 @Composable
 fun ListScreen(
@@ -39,6 +41,7 @@ fun ListScreen(
     onDismissClipboardForever: () -> Unit,
 ) {
     var showSheet by remember { mutableStateOf(false) }
+    val focusManager = LocalFocusManager.current
 
     Scaffold(
         containerColor = AppColors.AppBackground,
@@ -58,7 +61,8 @@ fun ListScreen(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(innerPadding)
-                .padding(horizontal = 20.dp),
+                .padding(horizontal = 20.dp)
+                .addFocusCleaner(focusManager),
         ) {
             Spacer(modifier = Modifier.height(16.dp))
 

--- a/app/src/main/java/com/devhjs/ttackjigeum_android/presentation/list/ListViewModel.kt
+++ b/app/src/main/java/com/devhjs/ttackjigeum_android/presentation/list/ListViewModel.kt
@@ -8,6 +8,7 @@ import com.devhjs.ttackjigeum_android.core.util.Result
 import com.devhjs.ttackjigeum_android.core.util.ShareIntentHandler
 import com.devhjs.ttackjigeum_android.domain.usecase.AddProductUseCase
 import com.devhjs.ttackjigeum_android.domain.usecase.DeleteProductUseCase
+import com.devhjs.ttackjigeum_android.domain.usecase.GetProductsUseCase
 import com.devhjs.ttackjigeum_android.domain.usecase.SearchProductsUseCase
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -15,13 +16,14 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 class ListViewModel(
+    private val getProductsUseCase: GetProductsUseCase,
     private val searchProductsUseCase: SearchProductsUseCase,
     private val addProductUseCase: AddProductUseCase,
     private val deleteProductUseCase: DeleteProductUseCase,
@@ -35,35 +37,41 @@ class ListViewModel(
     val event = _event.asSharedFlow()
 
     init {
+        observeProducts()
+        observeShareIntent()
+    }
+
+    private fun observeProducts() {
         viewModelScope.launch {
-            // 반응형 데이터 로딩
-            _state
-                .map { it.searchQuery }
-                .distinctUntilChanged()
-                .flatMapLatest { query ->
-                    _state.update { it.copy(isLoading = true) }
-                    searchProductsUseCase(query)
-                }
-                .collect { result ->
-                     when (result) {
-                        is Result.Success -> {
-                            _state.update {
-                                it.copy(
-                                    isLoading = false,
-                                    products = result.data,
-                                )
-                            }
-                        }
-                        is Result.Error -> {
-                            _state.update { it.copy(isLoading = false) }
-                            _event.emit(ListEvent.ShowToast("상품 정보를 불러오는데 실패했습니다."))
+            _state.update { it.copy(isLoading = true) }
+
+            combine(
+                getProductsUseCase(),
+                _state.map { it.searchQuery }.distinctUntilChanged()
+            ) { result, query ->
+                when (result) {
+                    is Result.Success -> {
+                        val filtered = searchProductsUseCase(result.data, query)
+                        _state.update {
+                            it.copy(
+                                isLoading = false,
+                                products = filtered
+                            )
                         }
                     }
-                }
-        }
 
+                    is Result.Error -> {
+                        _state.update { it.copy(isLoading = false) }
+                        _event.emit(ListEvent.ShowToast("상품 정보를 불러오는데 실패했습니다."))
+                    }
+                }
+            }.collect {}
+        }
+    }
+
+    private fun observeShareIntent() {
         viewModelScope.launch {
-             // 2. 공유 인텐트 대기 및 처리
+            // 2. 공유 인텐트 대기 및 처리
             ShareIntentHandler.sharedUrl.collectLatest { url ->
                 url?.let {
                     _state.update { it.copy(isLoading = true) }
@@ -81,21 +89,26 @@ class ListViewModel(
                     _event.emit(ListEvent.NavigateToDetail(action.product.id))
                 }
             }
+
             is ListAction.OnNotificationClick -> {
                 // 알림 화면 이동 로직 등 처리
             }
+
             is ListAction.OnAddLinkConfirm -> {
                 viewModelScope.launch {
                     _state.update { it.copy(isLoading = true) }
                     handleOnAddLinkConfirm(action.link)
                 }
             }
+
             is ListAction.OnSearchQueryChange -> {
                 _state.update { it.copy(searchQuery = action.query) }
             }
+
             is ListAction.OnSwipeDelete -> {
                 _state.update { it.copy(productToDelete = action.product) }
             }
+
             is ListAction.OnDeleteConfirm -> {
                 val product = _state.value.productToDelete
                 if (product != null) {
@@ -105,6 +118,7 @@ class ListViewModel(
                     }
                 }
             }
+
             is ListAction.OnDeleteCancel -> {
                 _state.update { it.copy(productToDelete = null) }
             }
@@ -116,8 +130,9 @@ class ListViewModel(
             is Result.Success -> {
                 // Flow를 통해 자동 업데이트됨
                 clipboardStateManager.markUrlProcessed(link)
-      
+
             }
+
             is Result.Error -> {
                 _state.update { it.copy(isLoading = false) }
                 val msg = when (result.error) {
@@ -135,12 +150,14 @@ class ListViewModel(
                 // Flow를 통해 자동 업데이트됨
                 _event.emit(ListEvent.ShowToast("상품이 삭제되었습니다."))
             }
+
             is Result.Error -> {
                 _state.update { it.copy(isLoading = false) }
                 _event.emit(ListEvent.ShowToast("상품 삭제에 실패했습니다."))
             }
         }
     }
+
     fun shouldShowClipboardPrompt(url: String): Boolean {
         return clipboardStateManager.shouldShowSnackbar(url)
     }

--- a/app/src/test/java/com/devhjs/ttackjigeum_android/domain/usecase/SearchProductsUseCaseTest.kt
+++ b/app/src/test/java/com/devhjs/ttackjigeum_android/domain/usecase/SearchProductsUseCaseTest.kt
@@ -1,24 +1,13 @@
 package com.devhjs.ttackjigeum_android.domain.usecase
 
-import com.devhjs.ttackjigeum_android.core.util.DataError
-import com.devhjs.ttackjigeum_android.core.util.Result
 import com.devhjs.ttackjigeum_android.domain.model.Product
-import io.mockk.coEvery
-import io.mockk.every
-import io.mockk.mockk
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class SearchProductsUseCaseTest {
 
-    private lateinit var getProductsUseCase: GetProductsUseCase
     private lateinit var searchProductsUseCase: SearchProductsUseCase
 
     private val sampleProducts = listOf(
@@ -29,65 +18,36 @@ class SearchProductsUseCaseTest {
 
     @Before
     fun setUp() {
-        getProductsUseCase = mockk()
-        searchProductsUseCase = SearchProductsUseCase(getProductsUseCase)
+        searchProductsUseCase = SearchProductsUseCase()
     }
 
     @Test
-    fun `invoke with empty query returns all products`() = runTest {
-        // Given
-        every { getProductsUseCase() } returns flowOf(Result.Success(sampleProducts))
-
+    fun `invoke with empty query returns all products`() {
         // When
-        val result = searchProductsUseCase("").first()
+        val result = searchProductsUseCase(sampleProducts, "")
 
         // Then
-        assertTrue(result is Result.Success)
-        val data = (result as Result.Success).data
-        assertEquals(3, data.size)
+        assertEquals(3, result.size)
+        assertEquals(sampleProducts, result)
     }
 
     @Test
-    fun `invoke with query returns filtered products`() = runTest {
-        // Given
-        every { getProductsUseCase() } returns flowOf(Result.Success(sampleProducts))
-
+    fun `invoke with query returns filtered products`() {
         // When
-        val result = searchProductsUseCase("Apple").first()
+        val result = searchProductsUseCase(sampleProducts, "Apple")
 
         // Then
-        assertTrue(result is Result.Success)
-        val data = (result as Result.Success).data
-        assertEquals(2, data.size) // iPhone and iPad
-        assertTrue(data.all { it.name.contains("Apple") })
+        assertEquals(2, result.size) // iPhone and iPad
+        assertTrue(result.all { it.name.contains("Apple") })
     }
 
     @Test
-    fun `invoke with query is case insensitive`() = runTest {
-        // Given
-        every { getProductsUseCase() } returns flowOf(Result.Success(sampleProducts))
-
+    fun `invoke with query is case insensitive`() {
         // When
-        val result = searchProductsUseCase("iphone").first()
+        val result = searchProductsUseCase(sampleProducts, "iphone")
 
         // Then
-        assertTrue(result is Result.Success)
-        val data = (result as Result.Success).data
-        assertEquals(1, data.size)
-        assertEquals("Apple iPhone", data[0].name)
-    }
-
-    @Test
-    fun `invoke propagates error from getProductsUseCase`() = runTest {
-        // Given
-        every { getProductsUseCase() } returns flowOf(Result.Error(DataError.Network.UNKNOWN))
-
-        // When
-        val result = searchProductsUseCase("query").first()
-
-        // Then
-        assertTrue(result is Result.Error)
-        val error = (result as Result.Error).error
-        assertEquals(DataError.Network.UNKNOWN, error)
+        assertEquals(1, result.size)
+        assertEquals("Apple iPhone", result[0].name)
     }
 }

--- a/app/src/test/java/com/devhjs/ttackjigeum_android/presentation/list/ListViewModelTest.kt
+++ b/app/src/test/java/com/devhjs/ttackjigeum_android/presentation/list/ListViewModelTest.kt
@@ -9,6 +9,7 @@ import com.devhjs.ttackjigeum_android.core.manager.ClipboardStateManager
 import com.devhjs.ttackjigeum_android.domain.model.Product
 import com.devhjs.ttackjigeum_android.domain.usecase.AddProductUseCase
 import com.devhjs.ttackjigeum_android.domain.usecase.DeleteProductUseCase
+import com.devhjs.ttackjigeum_android.domain.usecase.GetProductsUseCase
 import com.devhjs.ttackjigeum_android.domain.usecase.SearchProductsUseCase
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -16,6 +17,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.unmockkObject
+import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
@@ -37,6 +39,7 @@ class ListViewModelTest {
     @get:Rule
     val mainDispatcherRule = MainDispatcherRule(StandardTestDispatcher())
 
+    private lateinit var getProductsUseCase: GetProductsUseCase
     private lateinit var searchProductsUseCase: SearchProductsUseCase
     private lateinit var addProductUseCase: AddProductUseCase
     private lateinit var deleteProductUseCase: DeleteProductUseCase
@@ -45,6 +48,7 @@ class ListViewModelTest {
 
     @Before
     fun setUp() {
+        getProductsUseCase = mockk(relaxed = true)
         searchProductsUseCase = mockk(relaxed = true)
         addProductUseCase = mockk(relaxed = true)
         deleteProductUseCase = mockk(relaxed = true)
@@ -65,6 +69,7 @@ class ListViewModelTest {
 
     private fun initViewModel() {
         viewModel = ListViewModel(
+            getProductsUseCase = getProductsUseCase,
             searchProductsUseCase = searchProductsUseCase,
             addProductUseCase = addProductUseCase,
             deleteProductUseCase = deleteProductUseCase,
@@ -75,7 +80,8 @@ class ListViewModelTest {
     @Test
     // 초기화 시 초기 상태 검증
     fun `Initial state verification on initialization`() = runTest {
-        coEvery { searchProductsUseCase(any()) } returns flowOf(Result.Success(emptyList()))
+        every { getProductsUseCase() } returns flowOf(Result.Success(emptyList()))
+        every { searchProductsUseCase(any(), any()) } returns emptyList()
         initViewModel()
         advanceUntilIdle()
 
@@ -88,7 +94,10 @@ class ListViewModelTest {
     @Test
     // 검색어 업데이트 시 상품 검색 트리거
     fun `Search query update triggers product search`() = runTest {
-        coEvery { searchProductsUseCase(any()) } returns flowOf(Result.Success(emptyList()))
+        val testProducts = listOf(mockk<Product>())
+        every { getProductsUseCase() } returns flowOf(Result.Success(testProducts))
+        every { searchProductsUseCase(testProducts, any()) } returns testProducts
+
         initViewModel()
         advanceUntilIdle()
 
@@ -98,13 +107,14 @@ class ListViewModelTest {
 
         val state = viewModel.state.value
         assertEquals(query, state.searchQuery)
-        coVerify { searchProductsUseCase(query) }
+        verify { searchProductsUseCase(testProducts, query) }
     }
 
     @Test
     // 링크 추가 확인 시 상품 추가 유스케이스 트리거
     fun `OnAddLinkConfirm triggers add product use case`() = runTest {
-        coEvery { searchProductsUseCase(any()) } returns flowOf(Result.Success(emptyList()))
+        every { getProductsUseCase() } returns flowOf(Result.Success(emptyList()))
+        every { searchProductsUseCase(any(), any()) } returns emptyList()
         coEvery { addProductUseCase(any()) } returns Result.Success(Unit)
 
         initViewModel()
@@ -115,13 +125,14 @@ class ListViewModelTest {
         advanceUntilIdle()
 
         coVerify { addProductUseCase(link) }
-        io.mockk.verify { clipboardStateManager.markUrlProcessed(link) }
+        verify { clipboardStateManager.markUrlProcessed(link) }
     }
 
     @Test
     // 스와이프 삭제 시 삭제할 상품 설정
     fun `OnSwipeDelete sets product to delete`() = runTest {
-        coEvery { searchProductsUseCase(any()) } returns flowOf(Result.Success(emptyList()))
+        every { getProductsUseCase() } returns flowOf(Result.Success(emptyList()))
+        every { searchProductsUseCase(any(), any()) } returns emptyList()
         initViewModel()
         advanceUntilIdle()
 
@@ -139,7 +150,8 @@ class ListViewModelTest {
     @Test
     // 삭제 확인 시 상품 삭제 유스케이스 트리거
     fun `OnDeleteConfirm triggers delete product use case`() = runTest {
-        coEvery { searchProductsUseCase(any()) } returns flowOf(Result.Success(emptyList()))
+        every { getProductsUseCase() } returns flowOf(Result.Success(emptyList()))
+        every { searchProductsUseCase(any(), any()) } returns emptyList()
         coEvery { deleteProductUseCase(any()) } returns Result.Success(Unit)
 
         initViewModel()
@@ -164,7 +176,8 @@ class ListViewModelTest {
     @Test
     // 삭제 취소 시 삭제할 상품 초기화
     fun `OnDeleteCancel clears product to delete`() = runTest {
-        coEvery { searchProductsUseCase(any()) } returns flowOf(Result.Success(emptyList()))
+        every { getProductsUseCase() } returns flowOf(Result.Success(emptyList()))
+        every { searchProductsUseCase(any(), any()) } returns emptyList()
         initViewModel()
         advanceUntilIdle()
 
@@ -183,7 +196,8 @@ class ListViewModelTest {
     @Test
     // 공유 인텐트 핸들러가 상품 추가 트리거
     fun `ShareIntentHandler triggers add product`() = runTest {
-        coEvery { searchProductsUseCase(any()) } returns flowOf(Result.Success(emptyList()))
+        every { getProductsUseCase() } returns flowOf(Result.Success(emptyList()))
+        every { searchProductsUseCase(any(), any()) } returns emptyList()
         coEvery { addProductUseCase(any()) } returns Result.Success(Unit)
 
         val sharedUrl = "http://shared.com"
@@ -199,7 +213,8 @@ class ListViewModelTest {
     @Test
     // 에러 발생 시 토스트 메시지 표시
     fun `Error handling shows toast`() = runTest {
-        coEvery { searchProductsUseCase(any()) } returns flowOf(Result.Error(DataError.Network.UNKNOWN))
+        every { getProductsUseCase() } returns flowOf(Result.Error(DataError.Network.UNKNOWN))
+        every { searchProductsUseCase(any(), any()) } returns emptyList()
 
         initViewModel()
 
@@ -217,7 +232,7 @@ class ListViewModelTest {
         every { clipboardStateManager.shouldShowSnackbar(url) } returns true
 
         assertTrue(viewModel.shouldShowClipboardPrompt(url))
-        io.mockk.verify { clipboardStateManager.shouldShowSnackbar(url) }
+        verify { clipboardStateManager.shouldShowSnackbar(url) }
     }
 
     @Test
@@ -225,6 +240,6 @@ class ListViewModelTest {
         initViewModel()
         val url = "http://test.com"
         viewModel.setClipboardDismissed(url)
-        io.mockk.verify { clipboardStateManager.setDismissed(url) }
+        verify { clipboardStateManager.setDismissed(url) }
     }
 }


### PR DESCRIPTION
<!--
PR 제목 규칙 반드시 지켜주세요
[Feat] 기능 요약 (#이슈번호)
[Fix] 버그 요약 (#이슈번호)
[Refacotr] 리팩토링 요약 (#이슈번호)
등등
-->

## 🧪 Topic

<!-- 해당하는 작업 주제를 선택해주세요 -->

- [ ] 기능 추가
- [ ] 리뷰 반영
- [X] 리팩토링
- [X] 버그 수정
- [ ] 컨벤션 수정

## 📌 Summary

- SearchProductsUseCase를 Flow 기반에서 일반 리스트 필터링 방식으로 변경
- ListViewModel에서 GetProductsUseCase와 검색 쿼리를 combine하여 처리하도록 로직 개선
- SearchBar에 키보드 닫기 시 포커스 자동 해제 및 검색 버튼 액션 추가
- 화면 빈 공간 터치 시 포커스를 해제하는 addFocusCleaner 확장 함수 적용
- 유스케이스 및 뷰모델 변경 사항에 맞추어 단위 테스트 코드 수정


## 🔍 Related Issue

<!-- Issue Close 를 하고 싶지 않다면 Closes 를 지워주세요 -->

- #107 

## 📸 Screen Shot (Optional)

<!-- UI 변경 사항이 있다면 스크린샷이나 GIF로 첨부해주세요. -->
**기존 오류**
<img src="https://github.com/user-attachments/assets/6b32b28c-b889-4c6e-ab96-485bdadc114c" height="350"/>



## 비고 / 참고 사항

<!-- 리뷰어 참고사항이 있다면 작성해주세요. -->
기존에는 검색어 입력마다 GetProductsUseCase를 재호출하여 DB 조회, UI 깜빡임, cancel 에러 토스트 문제가 발생했습니다.
현재는 상품 목록을 Flow로 한 번 구독하고 , 검색어와 combine하여 메모리에서 필터링합니다.
이를 통해 불필요한 DB 재조회 없이 검색 UX를 개선하고, 데이터 변경도 실시간으로 반영되도록 수정했습니다.